### PR TITLE
Feature/json schema for keybindings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "yaml.schemas": {
+        "schemas/keybindings.json": [
+            "default-warp-keybindings.yaml",
+            "emacs.yaml"
+        ]
+    }
+}

--- a/schemas/keybindings.json
+++ b/schemas/keybindings.json
@@ -5,7 +5,7 @@
             "type": "string",
             "minLength": 1,
             "not": {
-                "pattern": "---|([^-]+)-\\1"
+                "pattern": "---"
             },
             "examples": [
                 "ctrl-",
@@ -19,369 +19,676 @@
     "description": "Keybindings",
     "type": "object",
     "properties": {
-        "editor_view:add_cursor_below": {
-            "title": "editor_view:add_cursor_below",
-            "description": "Adds cursor below",
+        "pane_group:add_right": {
+            "title": "pane_group:add_right",
+            "description": "Split pane right",
+            "default": "CMD-D",
             "$ref": "#/definitions/key"
         },
-        "editor_view:add_cursor_above": {
-            "title": "editor_view:add_cursor_above",
-            "description": "Adds cursor above",
+        "workspace:toggle_launch_config_palette": {
+            "title": "workspace:toggle_launch_config_palette",
+            "description": "Launch configuration palette",
+            "default": "CTRL-CMD-L",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:show_theme_chooser": {
+            "title": "workspace:show_theme_chooser",
+            "description": "Open theme picker",
+            "default": "CTRL-CMD-T",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:show_command_search": {
+            "title": "workspace:show_command_search",
+            "description": "Command search",
+            "default": "CTRL-R",
+            "$ref": "#/definitions/key"
+        },
+        "input:toggle_workflows": {
+            "title": "input:toggle_workflows",
+            "description": "Workflows",
+            "default": "CTRL-SHIFT-R",
+            "$ref": "#/definitions/key"
+        },
+        "input:toggle_natural_language_command_search": {
+            "title": "input:toggle_natural_language_command_search",
+            "description": "Ai command suggestions",
+            "default": "CTRL-`",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:select_bookmark_down": {
+            "title": "terminal:select_bookmark_down",
+            "description": "Select the closest bookmark down",
+            "default": "ALT-DOWN",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:copy_outputs": {
+            "title": "terminal:copy_outputs",
+            "description": "Copy command output",
+            "default": "ALT-SHIFT-CMD-C",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:select_bookmark_up": {
+            "title": "terminal:select_bookmark_up",
+            "description": "Select the closest bookmark up",
+            "default": "ALT-UP",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:select_all_blocks": {
+            "title": "terminal:select_all_blocks",
+            "description": "Select all blocks",
+            "default": "CMD-A",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:clear_blocks": {
+            "title": "terminal:clear_blocks",
+            "description": "Clear blocks",
+            "default": "CMD-K",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:bookmark_selected_block": {
+            "title": "terminal:bookmark_selected_block",
+            "description": "Bookmark selected block",
+            "default": "CMD-B",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:select_next_block": {
+            "title": "terminal:select_next_block",
+            "description": "Select next block",
+            "default": "CMD-DOWN",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:reinput_commands": {
+            "title": "terminal:reinput_commands",
+            "description": "Reinput selected commands",
+            "default": "CMD-I",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:focus_input": {
+            "title": "terminal:focus_input",
+            "description": "Focus terminal input",
+            "default": "CMD-L",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:select_previous_block": {
+            "title": "terminal:select_previous_block",
+            "description": "Select previous block",
+            "default": "CMD-UP",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:open_block_list_context_menu_via_keybinding": {
+            "title": "terminal:open_block_list_context_menu_via_keybinding",
+            "description": "Open block context menu",
+            "default": "CTRL-M",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:copy_commands": {
+            "title": "terminal:copy_commands",
+            "description": "Copy command",
+            "default": "SHIFT-CMD-C",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:reinput_commands_with_sudo": {
+            "title": "terminal:reinput_commands_with_sudo",
+            "description": "Reinput selected commands as root",
+            "default": "SHIFT-CMD-I",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:open_share_modal": {
+            "title": "terminal:open_share_modal",
+            "description": "Share selected block",
+            "default": "SHIFT-CMD-S",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:expand_block_selection_below": {
+            "title": "terminal:expand_block_selection_below",
+            "description": "Expand selected blocks below",
+            "default": "SHIFT-DOWN",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:expand_block_selection_above": {
+            "title": "terminal:expand_block_selection_above",
+            "description": "Expand selected blocks above",
+            "default": "SHIFT-UP",
+            "$ref": "#/definitions/key"
+        },
+        "editor:delete_word_left": {
+            "title": "editor:delete_word_left",
+            "description": "Delete word left",
+            "default": "ALT-BACKSPACE",
             "$ref": "#/definitions/key"
         },
         "editor_view:fold_selected_ranges": {
             "title": "editor_view:fold_selected_ranges",
-            "description": "Folds selected ranges",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:unfold": {
-            "title": "editor_view:unfold",
-            "description": "Unfolds",
+            "description": "Fold selected ranges",
+            "default": "ALT-CMD-F",
             "$ref": "#/definitions/key"
         },
         "editor_view:fold": {
             "title": "editor_view:fold",
             "description": "Fold",
+            "default": "ALT-CMD-[",
             "$ref": "#/definitions/key"
         },
-        "editor_view:add_next_occurrence": {
-            "title": "editor_view:add_next_occurrence",
-            "description": "Adds selection for next occurrence",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:clear_and_copy_lines": {
-            "title": "editor_view:clear_and_copy_lines",
-            "description": "Copies and Clears selected lines",
-            "$ref": "#/definitions/key"
-        },
-        "editor:select_to_line_end": {
-            "title": "editor:select_to_line_end",
-            "description": "Selects to end of line",
-            "$ref": "#/definitions/key"
-        },
-        "editor:select_to_line_start": {
-            "title": "editor:select_to_line_start",
-            "description": "Selects to start of line",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:insert_autosuggestion_text_and_update_selection": {
-            "title": "editor_view:insert_autosuggestion_text_and_update_selection",
-            "description": "Accepts Autosuggestion",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:delete_all_left": {
-            "title": "editor_view:delete_all_left",
-            "description": "Deletes all left",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:delete_all_right": {
-            "title": "editor_view:delete_all_right",
-            "description": "Deletes all right",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:cut_all_right": {
-            "title": "editor_view:cut_all_right",
-            "description": "Cuts all right",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:clear_lines": {
-            "title": "editor_view:clear_lines",
-            "description": "Clears selected lines",
+        "editor_view:unfold": {
+            "title": "editor_view:unfold",
+            "description": "Unfold",
+            "default": "ALT-CMD-]",
             "$ref": "#/definitions/key"
         },
         "editor:delete_word_right": {
             "title": "editor:delete_word_right",
-            "description": "Deletes word right",
+            "description": "Delete word right",
+            "default": "ALT-DELETE",
             "$ref": "#/definitions/key"
         },
-        "editor_view:cut_word_right": {
-            "title": "editor_view:cut_word_right",
-            "description": "Cuts word right",
+        "editor_view:select_all": {
+            "title": "editor_view:select_all",
+            "description": "Select all",
+            "default": "CMD-A",
             "$ref": "#/definitions/key"
         },
-        "editor:delete_word_left": {
-            "title": "editor:delete_word_left",
-            "description": "Deletes word left",
+        "editor_view:delete_all_left": {
+            "title": "editor_view:delete_all_left",
+            "description": "Delete all left",
+            "default": "CMD-BACKSPACE",
             "$ref": "#/definitions/key"
         },
-        "editor_view:cut_word_left": {
-            "title": "editor_view:cut_word_left",
-            "description": "Cuts word left",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:clear_buffer": {
-            "title": "editor_view:clear_buffer",
-            "description": "Clears command editor",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:backspace": {
-            "title": "editor_view:backspace",
-            "description": "Removes the previous character",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:move_to_buffer_end": {
-            "title": "editor_view:move_to_buffer_end",
-            "description": "Moves to the end of the buffer",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:move_to_buffer_start": {
-            "title": "editor_view:move_to_buffer_start",
-            "description": "Moves to the start of the buffer",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:move_to_paragraph_end": {
-            "title": "editor_view:move_to_paragraph_end",
-            "description": "Moves to the end of the paragraph",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:move_to_paragraph_start": {
-            "title": "editor_view:move_to_paragraph_start",
-            "description": "Moves to the start of the paragraph",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:move_backward_one_word": {
-            "title": "editor_view:move_backward_one_word",
-            "description": "Moves backward one word",
-            "$ref": "#/definitions/key"
-        },
-        "editor_view:move_forward_one_word": {
-            "title": "editor_view:move_forward_one_word",
-            "description": "Moves forward one word",
+        "editor_view:delete_all_right": {
+            "title": "editor_view:delete_all_right",
+            "description": "Delete all right",
+            "default": "CMD-DELETE",
             "$ref": "#/definitions/key"
         },
         "editor_view:cmd_down": {
             "title": "editor_view:cmd_down",
-            "description": "Moves cursor to the bottom",
+            "description": "Move cursor to the bottom",
+            "default": "CMD-DOWN",
             "$ref": "#/definitions/key"
         },
-        "editor_view:end": {
-            "title": "editor_view:end",
-            "description": "Ends",
+        "editor_view:cmd_i": {
+            "title": "editor_view:cmd_i",
+            "description": "Inspect command",
+            "default": "CMD-I",
             "$ref": "#/definitions/key"
         },
         "editor_view:home": {
             "title": "editor_view:home",
             "description": "Home",
+            "default": "CMD-LEFT",
             "$ref": "#/definitions/key"
         },
-        "editor_view:move_to_line_end": {
-            "title": "editor_view:move_to_line_end",
-            "description": "Moves to end of line",
+        "editor_view:end": {
+            "title": "editor_view:end",
+            "description": "End",
+            "default": "CMD-RIGHT",
             "$ref": "#/definitions/key"
         },
         "editor_view:move_to_line_start": {
             "title": "editor_view:move_to_line_start",
-            "description": "Moves to start of line",
+            "description": "Move to start of line",
+            "default": "CTRL-A",
             "$ref": "#/definitions/key"
         },
-        "editor_view:select_all": {
-            "title": "editor_view:select_all",
-            "description": "Selects all",
+        "editor_view:left": {
+            "title": "editor_view:left",
+            "description": "Move cursor left",
+            "default": "CTRL-B",
             "$ref": "#/definitions/key"
         },
-        "editor_view:select_down": {
-            "title": "editor_view:select_down",
-            "description": "Selects down",
+        "editor_view:clear_buffer": {
+            "title": "editor_view:clear_buffer",
+            "description": "Clear command editor",
+            "default": "CTRL-C",
             "$ref": "#/definitions/key"
         },
-        "editor_view:select_up": {
-            "title": "editor_view:select_up",
-            "description": "Selects up",
+        "editor_view:delete": {
+            "title": "editor_view:delete",
+            "description": "Delete",
+            "default": "CTRL-D",
             "$ref": "#/definitions/key"
         },
-        "editor_view:select_right": {
-            "title": "editor_view:select_right",
-            "description": "Selects one character to the right",
+        "editor_view:move_to_line_end": {
+            "title": "editor_view:move_to_line_end",
+            "description": "Move to end of line",
+            "default": "CTRL-E",
             "$ref": "#/definitions/key"
         },
-        "editor_view:select_left": {
-            "title": "editor_view:select_left",
-            "description": "Selects one character to the left",
+        "editor_view:right": {
+            "title": "editor_view:right",
+            "description": "Move cursor right / accept autosuggestion",
+            "default": "CTRL-F",
             "$ref": "#/definitions/key"
         },
-        "editor_view:select_right_by_word": {
-            "title": "editor_view:select_right_by_word",
-            "description": "Selects one word to the right",
+        "editor_view:add_next_occurrence": {
+            "title": "editor_view:add_next_occurrence",
+            "description": "Add selection for next occurrence",
+            "default": "CTRL-G",
             "$ref": "#/definitions/key"
         },
-        "editor_view:select_left_by_word": {
-            "title": "editor_view:select_left_by_word",
-            "description": "Selects one word to the left",
+        "editor_view:backspace": {
+            "title": "editor_view:backspace",
+            "description": "Remove the previous character",
+            "default": "CTRL-H",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:insert_newline": {
+            "title": "editor_view:insert_newline",
+            "description": "Insert newline",
+            "default": "CTRL-J",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:cut_all_right": {
+            "title": "editor_view:cut_all_right",
+            "description": "Cut all right",
+            "default": "CTRL-K",
             "$ref": "#/definitions/key"
         },
         "input:clear_screen": {
             "title": "input:clear_screen",
-            "description": "Clears screen",
+            "description": "Clear screen",
+            "default": "CTRL-L",
             "$ref": "#/definitions/key"
         },
-        "input:search_command_history": {
-            "title": "input:search_command_history",
-            "description": "Search command history",
+        "editor_view:down": {
+            "title": "editor_view:down",
+            "description": "Move cursor down",
+            "default": "CTRL-N",
             "$ref": "#/definitions/key"
         },
-        "terminal:clear_lines": {
-            "title": "terminal:clear_lines",
-            "description": "Clears blocks",
+        "editor_view:up": {
+            "title": "editor_view:up",
+            "description": "Move cursor up",
+            "default": "CTRL-P",
             "$ref": "#/definitions/key"
         },
-        "terminal:find": {
-            "title": "terminal:find",
-            "description": "Finds",
+        "editor_view:select_to_line_start": {
+            "title": "editor_view:select_to_line_start",
+            "description": "Select to start of line",
+            "default": "CTRL-SHIFT-A",
             "$ref": "#/definitions/key"
         },
-        "terminal:reinput_command_with_sudo": {
-            "title": "terminal:reinput_command_with_sudo",
-            "description": "Re-inputs selected command as root",
+        "editor_view:select_left": {
+            "title": "editor_view:select_left",
+            "description": "Select one character to the left",
+            "default": "CTRL-SHIFT-B",
             "$ref": "#/definitions/key"
         },
-        "terminal:reinput_command": {
-            "title": "terminal:reinput_command",
-            "description": "Re-inputs selected command",
+        "editor_view:add_cursor_below": {
+            "title": "editor_view:add_cursor_below",
+            "description": "Add cursor below",
+            "default": "CTRL-SHIFT-DOWN",
             "$ref": "#/definitions/key"
         },
-        "terminal:open_share_modal": {
-            "title": "terminal:open_share_modal",
-            "description": "Shares selected block",
+        "editor:select_to_line_end": {
+            "title": "editor:select_to_line_end",
+            "description": "Select to end of line",
+            "default": "CTRL-SHIFT-E",
             "$ref": "#/definitions/key"
         },
-        "terminal:copy_command": {
-            "title": "terminal:copy_command",
-            "description": "Copies command",
+        "editor:select_right": {
+            "title": "editor:select_right",
+            "description": "Select one character to the right",
+            "default": "CTRL-SHIFT-F",
             "$ref": "#/definitions/key"
         },
-        "terminal:copy_output": {
-            "title": "terminal:copy_output",
-            "description": "Copies command output",
+        "editor_view:select_down": {
+            "title": "editor_view:select_down",
+            "description": "Select down",
+            "default": "CTRL-SHIFT-N",
             "$ref": "#/definitions/key"
         },
-        "terminal:select_next_block": {
-            "title": "terminal:select_next_block",
-            "description": "Selects next block",
+        "editor_view:select_up": {
+            "title": "editor_view:select_up",
+            "description": "Select up",
+            "default": "CTRL-SHIFT-P",
             "$ref": "#/definitions/key"
         },
-        "terminal:select_previous_block": {
-            "title": "terminal:select_previous_block",
-            "description": "Selects previous block",
+        "editor_view:add_cursor_above": {
+            "title": "editor_view:add_cursor_above",
+            "description": "Add cursor above",
+            "default": "CTRL-SHIFT-UP",
             "$ref": "#/definitions/key"
         },
-        "terminal:copy": {
-            "title": "terminal:copy",
-            "description": "Copies",
+        "editor_view:clear_and_copy_lines": {
+            "title": "editor_view:clear_and_copy_lines",
+            "description": "Copy and clear selected lines",
+            "default": "CTRL-U",
             "$ref": "#/definitions/key"
         },
-        "terminal:paste": {
-            "title": "terminal:paste",
-            "description": "Pastes",
+        "editor_view:cut_word_left": {
+            "title": "editor_view:cut_word_left",
+            "description": "Cut word left",
+            "default": "CTRL-W",
             "$ref": "#/definitions/key"
         },
-        "terminal:focus_input": {
-            "title": "terminal:focus_input",
-            "description": "Focuses terminal input",
+        "editor:insert_last_word_previous_command": {
+            "title": "editor:insert_last_word_previous_command",
+            "description": "Insert last word of previous command",
+            "default": "META-.",
             "$ref": "#/definitions/key"
         },
-        "pane_group:resize_down": {
-            "title": "pane_group:resize_down",
-            "description": "Resizes pane > Move divider down",
+        "editor_view:move_to_paragraph_start": {
+            "title": "editor_view:move_to_paragraph_start",
+            "description": "Move to the start of the paragraph",
+            "default": "META-A",
             "$ref": "#/definitions/key"
         },
-        "pane_group:resize_up": {
-            "title": "pane_group:resize_up",
-            "description": "Resizes pane > Move divider up",
+        "editor_view:move_backward_one_word": {
+            "title": "editor_view:move_backward_one_word",
+            "description": "Move backward one word",
+            "default": "META-B",
             "$ref": "#/definitions/key"
         },
-        "pane_group:resize_right": {
-            "title": "pane_group:resize_right",
-            "description": "Resizes pane > Move divider right",
+        "editor_view:cut_word_right": {
+            "title": "editor_view:cut_word_right",
+            "description": "Cut word right",
+            "default": "META-D",
             "$ref": "#/definitions/key"
         },
-        "pane_group:resize_left": {
-            "title": "pane_group:resize_left",
-            "description": "Resizes pane > Move divider left",
+        "editor_view:move_to_paragraph_end": {
+            "title": "editor_view:move_to_paragraph_end",
+            "description": "Move to the end of the paragraph",
+            "default": "META-E",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_forward_one_word": {
+            "title": "editor_view:move_forward_one_word",
+            "description": "Move forward one word",
+            "default": "META-F",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_backward_one_subword": {
+            "title": "editor_view:move_backward_one_subword",
+            "description": "Move backward one subword",
+            "default": "CTRL-OPT-LEFT",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_forward_one_subword": {
+            "title": "editor_view:move_forward_one_subword",
+            "description": "Move forward one subword",
+            "default": "CTRL-OPT-RIGHT",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:clear_lines": {
+            "title": "editor_view:clear_lines",
+            "description": "Clear selected lines",
+            "default": "SHIFT-CMD-K",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_to_buffer_start": {
+            "title": "editor_view:move_to_buffer_start",
+            "description": "Move to the start of the buffer",
+            "default": "SHIFT-META-<",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_to_buffer_end": {
+            "title": "editor_view:move_to_buffer_end",
+            "description": "Move to the end of the buffer",
+            "default": "SHIFT-META->",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_left_by_word": {
+            "title": "editor_view:select_left_by_word",
+            "description": "Select one word to the left",
+            "default": "SHIFT-META-B",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_right_by_word": {
+            "title": "editor_view:select_right_by_word",
+            "description": "Select one word to the right",
+            "default": "SHIFT-META-F",
             "$ref": "#/definitions/key"
         },
         "pane_group:navigate_down": {
             "title": "pane_group:navigate_down",
-            "description": "Switches panes down",
-            "$ref": "#/definitions/key"
-        },
-        "pane_group:navigate_up": {
-            "title": "pane_group:navigate_up",
-            "description": "Switches panes up",
-            "$ref": "#/definitions/key"
-        },
-        "pane_group:navigate_right": {
-            "title": "pane_group:navigate_right",
-            "description": "Switches panes right",
+            "description": "Switch panes down",
+            "default": "ALT-CMD-DOWN",
             "$ref": "#/definitions/key"
         },
         "pane_group:navigate_left": {
             "title": "pane_group:navigate_left",
-            "description": "Switches panes left",
+            "description": "Switch panes left",
+            "default": "ALT-CMD-LEFT",
             "$ref": "#/definitions/key"
         },
-        "pane_group:add_vertical": {
-            "title": "pane_group:add_vertical",
-            "description": "Splits pane down",
+        "pane_group:navigate_right": {
+            "title": "pane_group:navigate_right",
+            "description": "Switch panes right",
+            "default": "ALT-CMD-RIGHT",
             "$ref": "#/definitions/key"
         },
-        "pane_group:add_horizontal": {
-            "title": "pane_group:add_horizontal",
-            "description": "Splits pane right",
+        "pane_group:navigate_up": {
+            "title": "pane_group:navigate_up",
+            "description": "Switch panes up",
+            "default": "ALT-CMD-UP",
             "$ref": "#/definitions/key"
         },
-        "pane_group:navigate_next": {
-            "title": "pane_group:navigate_next",
-            "description": "Navigates  to next pane",
+        "workspace:set_a11y_concise_verbosity_level": {
+            "title": "workspace:set_a11y_concise_verbosity_level",
+            "description": "[a11y] set concise accessibility announcements",
+            "default": "ALT-CMD-V",
             "$ref": "#/definitions/key"
         },
-        "pane_group:navigate_prev": {
-            "title": "pane_group:navigate_prev",
-            "description": "Navigates  to previous pane",
+        "workspace:set_a11y_verbose_verbosity_level": {
+            "title": "workspace:set_a11y_verbose_verbosity_level",
+            "description": "[a11y] set verbose accessibility announcements",
+            "default": "ALT-CMD-V",
             "$ref": "#/definitions/key"
         },
-        "workspace:show_keybinding_settings": {
-            "title": "workspace:show_keybinding_settings",
-            "description": "Opens keybindings editor",
+        "workspace:show_settings_modal": {
+            "title": "workspace:show_settings_modal",
+            "description": "Open settings",
+            "default": "CMD-,",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:show_settings_account_page": {
+            "title": "workspace:show_settings_account_page",
+            "description": "Open settings: account",
+            "default": "CMD-,",
+            "$ref": "#/definitions/key"
+        },
+        "find:find_next_occurrence": {
+            "title": "find:find_next_occurrence",
+            "description": "Find the next occurrence of your search query",
+            "default": "CMD-G",
             "$ref": "#/definitions/key"
         },
         "workspace:toggle_command_palette": {
             "title": "workspace:toggle_command_palette",
             "description": "Toggle command palette",
+            "default": "CMD-P",
             "$ref": "#/definitions/key"
         },
-        "workspace:show_theme_chooser": {
-            "title": "workspace:show_theme_chooser",
-            "description": "Opens theme picker",
+        "workspace:toggle_mouse_reporting": {
+            "title": "workspace:toggle_mouse_reporting",
+            "description": "Toggle mouse reporting",
+            "default": "CMD-R",
             "$ref": "#/definitions/key"
         },
-        "workspace:reset_font_size": {
-            "title": "workspace:reset_font_size",
-            "description": "Resets font size to default",
+        "pane_group:navigate_prev": {
+            "title": "pane_group:navigate_prev",
+            "description": "Activate previous pane",
+            "default": "CMD-[",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:navigate_next": {
+            "title": "pane_group:navigate_next",
+            "description": "Activate next pane",
+            "default": "CMD-]",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:resize_down": {
+            "title": "pane_group:resize_down",
+            "description": "Resize pane > move divider down",
+            "default": "CTRL-CMD-DOWN",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:show_keybinding_settings": {
+            "title": "workspace:show_keybinding_settings",
+            "description": "Open keybindings editor",
+            "default": "CTRL-CMD-K",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:resize_left": {
+            "title": "pane_group:resize_left",
+            "description": "Resize pane > move divider left",
+            "default": "CTRL-CMD-LEFT",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:resize_right": {
+            "title": "pane_group:resize_right",
+            "description": "Resize pane > move divider right",
+            "default": "CTRL-CMD-RIGHT",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:resize_up": {
+            "title": "pane_group:resize_up",
+            "description": "Resize pane > move divider up",
+            "default": "CTRL-CMD-UP",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:toggle_resource_center": {
+            "title": "workspace:toggle_resource_center",
+            "description": "Open resource center",
+            "default": "CTRL-SHIFT-?",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:add_down": {
+            "title": "pane_group:add_down",
+            "description": "Split pane down",
+            "default": "SHIFT-CMD-D",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:toggle_maximize_pane": {
+            "title": "pane_group:toggle_maximize_pane",
+            "description": "Toggle maximize active pane",
+            "default": "SHIFT-CMD-ENTER",
+            "$ref": "#/definitions/key"
+        },
+        "find:find_prev_occurrence": {
+            "title": "find:find_prev_occurrence",
+            "description": "Find the previous occurrence of your search query",
+            "default": "SHIFT-CMD-G",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:toggle_navigation_palette": {
+            "title": "workspace:toggle_navigation_palette",
+            "description": "Toggle navigation palette",
+            "default": "SHIFT-CMD-P",
             "$ref": "#/definitions/key"
         },
         "workspace:decrease_font_size": {
             "title": "workspace:decrease_font_size",
-            "description": "Decreases font size",
+            "description": "Decrease font size",
+            "default": "CMD--",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:reset_font_size": {
+            "title": "workspace:reset_font_size",
+            "description": "Reset font size to default",
+            "default": "CMD-0",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_first_tab": {
+            "title": "workspace:activate_first_tab",
+            "description": "Switch to 1st tab",
+            "default": "CMD-1",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_second_tab": {
+            "title": "workspace:activate_second_tab",
+            "description": "Switch to 2nd tab",
+            "default": "CMD-2",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_third_tab": {
+            "title": "workspace:activate_third_tab",
+            "description": "Switch to 3rd tab",
+            "default": "CMD-3",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_fourth_tab": {
+            "title": "workspace:activate_fourth_tab",
+            "description": "Switch to 4th tab",
+            "default": "CMD-4",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_fifth_tab": {
+            "title": "workspace:activate_fifth_tab",
+            "description": "Switch to 5th tab",
+            "default": "CMD-5",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_sixth_tab": {
+            "title": "workspace:activate_sixth_tab",
+            "description": "Switch to 6th tab",
+            "default": "CMD-6",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_seventh_tab": {
+            "title": "workspace:activate_seventh_tab",
+            "description": "Switch to 7th tab",
+            "default": "CMD-7",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_eighth_tab": {
+            "title": "workspace:activate_eighth_tab",
+            "description": "Switch to 8th tab",
+            "default": "CMD-8",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_last_tab": {
+            "title": "workspace:activate_last_tab",
+            "description": "Switch to last tab",
+            "default": "CMD-9",
             "$ref": "#/definitions/key"
         },
         "workspace:increase_font_size": {
             "title": "workspace:increase_font_size",
-            "description": "Increases font size",
+            "description": "Increase font size",
+            "default": "CMD-=",
             "$ref": "#/definitions/key"
         },
-        "workspace:activate_next_tab": {
-            "title": "workspace:activate_next_tab",
-            "description": "Activates next tab",
+        "terminal:copy": {
+            "title": "terminal:copy",
+            "description": "Copy",
+            "default": "CMD-C",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:find": {
+            "title": "terminal:find",
+            "description": "Find",
+            "default": "CMD-F",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:paste": {
+            "title": "terminal:paste",
+            "description": "Paste",
+            "default": "CMD-V",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:move_tab_left": {
+            "title": "workspace:move_tab_left",
+            "description": "Move tab left",
+            "default": "CTRL-SHIFT-LEFT",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:move_tab_right": {
+            "title": "workspace:move_tab_right",
+            "description": "Move tab right",
+            "default": "CTRL-SHIFT-RIGHT",
             "$ref": "#/definitions/key"
         },
         "workspace:activate_prev_tab": {
             "title": "workspace:activate_prev_tab",
-            "description": "Activates previous tab",
+            "description": "Activate previous tab",
+            "default": "SHIFT-CMD-{",
             "$ref": "#/definitions/key"
         },
-        "workspace:show_settings_modal": {
-            "title": "workspace:show_settings_modal",
-            "description": "Opens settings",
+        "workspace:activate_next_tab": {
+            "title": "workspace:activate_next_tab",
+            "description": "Activate next tab",
+            "default": "SHIFT-CMD-}",
             "$ref": "#/definitions/key"
         }
     },

--- a/schemas/keybindings.json
+++ b/schemas/keybindings.json
@@ -1,0 +1,386 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "key": {
+            "type": "string",
+            "minLength": 1,
+            "examples": [
+                "ctrl-",
+                "alt-",
+                "shift-",
+                "cmd-"
+            ]
+        }
+    },
+    "title": "keybindings",
+    "description": "Keybindings",
+    "type": "object",
+    "properties": {
+        "editor_view:add_cursor_below": {
+            "title": "editor_view:add_cursor_below",
+            "description": "Adds cursor below",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:add_cursor_above": {
+            "title": "editor_view:add_cursor_above",
+            "description": "Adds cursor above",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:fold_selected_ranges": {
+            "title": "editor_view:fold_selected_ranges",
+            "description": "Folds selected ranges",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:unfold": {
+            "title": "editor_view:unfold",
+            "description": "Unfolds",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:fold": {
+            "title": "editor_view:fold",
+            "description": "Fold",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:add_next_occurrence": {
+            "title": "editor_view:add_next_occurrence",
+            "description": "Adds selection for next occurrence",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:clear_and_copy_lines": {
+            "title": "editor_view:clear_and_copy_lines",
+            "description": "Copies and Clears selected lines",
+            "$ref": "#/definitions/key"
+        },
+        "editor:select_to_line_end": {
+            "title": "editor:select_to_line_end",
+            "description": "Selects to end of line",
+            "$ref": "#/definitions/key"
+        },
+        "editor:select_to_line_start": {
+            "title": "editor:select_to_line_start",
+            "description": "Selects to start of line",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:insert_autosuggestion_text_and_update_selection": {
+            "title": "editor_view:insert_autosuggestion_text_and_update_selection",
+            "description": "Accepts Autosuggestion",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:delete_all_left": {
+            "title": "editor_view:delete_all_left",
+            "description": "Deletes all left",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:delete_all_right": {
+            "title": "editor_view:delete_all_right",
+            "description": "Deletes all right",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:cut_all_right": {
+            "title": "editor_view:cut_all_right",
+            "description": "Cuts all right",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:clear_lines": {
+            "title": "editor_view:clear_lines",
+            "description": "Clears selected lines",
+            "$ref": "#/definitions/key"
+        },
+        "editor:delete_word_right": {
+            "title": "editor:delete_word_right",
+            "description": "Deletes word right",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:cut_word_right": {
+            "title": "editor_view:cut_word_right",
+            "description": "Cuts word right",
+            "$ref": "#/definitions/key"
+        },
+        "editor:delete_word_left": {
+            "title": "editor:delete_word_left",
+            "description": "Deletes word left",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:cut_word_left": {
+            "title": "editor_view:cut_word_left",
+            "description": "Cuts word left",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:clear_buffer": {
+            "title": "editor_view:clear_buffer",
+            "description": "Clears command editor",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:backspace": {
+            "title": "editor_view:backspace",
+            "description": "Removes the previous character",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_to_buffer_end": {
+            "title": "editor_view:move_to_buffer_end",
+            "description": "Moves to the end of the buffer",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_to_buffer_start": {
+            "title": "editor_view:move_to_buffer_start",
+            "description": "Moves to the start of the buffer",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_to_paragraph_end": {
+            "title": "editor_view:move_to_paragraph_end",
+            "description": "Moves to the end of the paragraph",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_to_paragraph_start": {
+            "title": "editor_view:move_to_paragraph_start",
+            "description": "Moves to the start of the paragraph",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_backward_one_word": {
+            "title": "editor_view:move_backward_one_word",
+            "description": "Moves backward one word",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_forward_one_word": {
+            "title": "editor_view:move_forward_one_word",
+            "description": "Moves forward one word",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:cmd_down": {
+            "title": "editor_view:cmd_down",
+            "description": "Moves cursor to the bottom",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:end": {
+            "title": "editor_view:end",
+            "description": "Ends",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:home": {
+            "title": "editor_view:home",
+            "description": "Home",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_to_line_end": {
+            "title": "editor_view:move_to_line_end",
+            "description": "Moves to end of line",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:move_to_line_start": {
+            "title": "editor_view:move_to_line_start",
+            "description": "Moves to start of line",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_all": {
+            "title": "editor_view:select_all",
+            "description": "Selects all",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_down": {
+            "title": "editor_view:select_down",
+            "description": "Selects down",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_up": {
+            "title": "editor_view:select_up",
+            "description": "Selects up",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_right": {
+            "title": "editor_view:select_right",
+            "description": "Selects one character to the right",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_left": {
+            "title": "editor_view:select_left",
+            "description": "Selects one character to the left",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_right_by_word": {
+            "title": "editor_view:select_right_by_word",
+            "description": "Selects one word to the right",
+            "$ref": "#/definitions/key"
+        },
+        "editor_view:select_left_by_word": {
+            "title": "editor_view:select_left_by_word",
+            "description": "Selects one word to the left",
+            "$ref": "#/definitions/key"
+        },
+        "input:clear_screen": {
+            "title": "input:clear_screen",
+            "description": "Clears screen",
+            "$ref": "#/definitions/key"
+        },
+        "input:search_command_history": {
+            "title": "input:search_command_history",
+            "description": "Search command history",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:clear_lines": {
+            "title": "terminal:clear_lines",
+            "description": "Clears blocks",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:find": {
+            "title": "terminal:find",
+            "description": "Finds",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:reinput_command_with_sudo": {
+            "title": "terminal:reinput_command_with_sudo",
+            "description": "Re-inputs selected command as root",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:reinput_command": {
+            "title": "terminal:reinput_command",
+            "description": "Re-inputs selected command",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:open_share_modal": {
+            "title": "terminal:open_share_modal",
+            "description": "Shares selected block",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:copy_command": {
+            "title": "terminal:copy_command",
+            "description": "Copies command",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:copy_output": {
+            "title": "terminal:copy_output",
+            "description": "Copies command output",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:select_next_block": {
+            "title": "terminal:select_next_block",
+            "description": "Selects next block",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:select_previous_block": {
+            "title": "terminal:select_previous_block",
+            "description": "Selects previous block",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:copy": {
+            "title": "terminal:copy",
+            "description": "Copies",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:paste": {
+            "title": "terminal:paste",
+            "description": "Pastes",
+            "$ref": "#/definitions/key"
+        },
+        "terminal:focus_input": {
+            "title": "terminal:focus_input",
+            "description": "Focuses terminal input",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:resize_down": {
+            "title": "pane_group:resize_down",
+            "description": "Resizes pane > Move divider down",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:resize_up": {
+            "title": "pane_group:resize_up",
+            "description": "Resizes pane > Move divider up",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:resize_right": {
+            "title": "pane_group:resize_right",
+            "description": "Resizes pane > Move divider right",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:resize_left": {
+            "title": "pane_group:resize_left",
+            "description": "Resizes pane > Move divider left",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:navigate_down": {
+            "title": "pane_group:navigate_down",
+            "description": "Switches panes down",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:navigate_up": {
+            "title": "pane_group:navigate_up",
+            "description": "Switches panes up",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:navigate_right": {
+            "title": "pane_group:navigate_right",
+            "description": "Switches panes right",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:navigate_left": {
+            "title": "pane_group:navigate_left",
+            "description": "Switches panes left",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:add_vertical": {
+            "title": "pane_group:add_vertical",
+            "description": "Splits pane down",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:add_horizontal": {
+            "title": "pane_group:add_horizontal",
+            "description": "Splits pane right",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:navigate_next": {
+            "title": "pane_group:navigate_next",
+            "description": "Navigates  to next pane",
+            "$ref": "#/definitions/key"
+        },
+        "pane_group:navigate_prev": {
+            "title": "pane_group:navigate_prev",
+            "description": "Navigates  to previous pane",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:show_keybinding_settings": {
+            "title": "workspace:show_keybinding_settings",
+            "description": "Opens keybindings editor",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:toggle_command_palette": {
+            "title": "workspace:toggle_command_palette",
+            "description": "Toggle command palette",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:show_theme_chooser": {
+            "title": "workspace:show_theme_chooser",
+            "description": "Opens theme picker",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:reset_font_size": {
+            "title": "workspace:reset_font_size",
+            "description": "Resets font size to default",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:decrease_font_size": {
+            "title": "workspace:decrease_font_size",
+            "description": "Decreases font size",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:increase_font_size": {
+            "title": "workspace:increase_font_size",
+            "description": "Increases font size",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_next_tab": {
+            "title": "workspace:activate_next_tab",
+            "description": "Activates next tab",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:activate_prev_tab": {
+            "title": "workspace:activate_prev_tab",
+            "description": "Activates previous tab",
+            "$ref": "#/definitions/key"
+        },
+        "workspace:show_settings_modal": {
+            "title": "workspace:show_settings_modal",
+            "description": "Opens settings",
+            "$ref": "#/definitions/key"
+        }
+    },
+    "additionalProperties": false
+}

--- a/schemas/keybindings.json
+++ b/schemas/keybindings.json
@@ -4,6 +4,9 @@
         "key": {
             "type": "string",
             "minLength": 1,
+            "not": {
+                "pattern": "---|([^-]+)-\\1"
+            },
             "examples": [
                 "ctrl-",
                 "alt-",


### PR DESCRIPTION
## Notes

- duplicating keys are prohibited, like `alt-alt`

![image](https://github.com/warpdotdev/keysets/assets/42812113/b3f59383-9254-4f11-9b11-b36fdfbde879)

![image](https://github.com/warpdotdev/keysets/assets/42812113/0c880aed-b30a-42f3-a1fd-6fa221220a84)

## Questions

![image](https://github.com/warpdotdev/keysets/assets/42812113/8dca35ca-7a39-45e4-adb3-9c3de5d3be02)

Are they correct (but still not documented [here](https://github.com/warpdotdev/keysets/blob/main/FORMAT.md#action-names)) or invalid? I see `editor:insert_last_word_previous_command` appears in [docs](https://docs.warp.dev/features/keyboard-shortcuts#input-editor). Is FORMAT.md just outdated?